### PR TITLE
CLI-11141 - Corrigido setAmount na transaction onde  valores ficam divergentes

### DIFF
--- a/src/Getnet/API/Transaction.php
+++ b/src/Getnet/API/Transaction.php
@@ -81,7 +81,7 @@ class Transaction implements \JsonSerializable
      */
     public function setAmount($amount)
     {
-        $this->amount = (int) ($amount * 100);
+        $this->amount = (int) round($amount * 100);
 
         return $this;
     }

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -13,6 +13,19 @@ final class TransactionTest extends TestBase
 
         $transaction->setAmount(76.89);
         $this->assertSame(7689, $transaction->getAmount());
+
+        $transaction->setAmount(2428.72);
+        $this->assertSame(242872, $transaction->getAmount());
+
+        $transaction->setAmount('2428.72');
+        $this->assertSame(242872, $transaction->getAmount());
+
+        $transaction->setAmount(299.9);
+        $this->assertSame(29990, $transaction->getAmount());
+
+        $transaction->setAmount('299.9');
+        $this->assertSame(29990, $transaction->getAmount());
+
         $transaction->setAmount('76.89');
         $this->assertSame(7689, $transaction->getAmount());
         


### PR DESCRIPTION
- Foi visto que em alguns valores específicos ao fazer o setAmount da transaction o valor ficava divergente do original ao fazer a multiplicação por 100, por exemplo o valor 299.9, se for retirado o round da função o valor resultado do setAmount vai ser 29989, e com isso vai divergente as informações da Climba e da Getnet.
- Nesse caso está ocasionando o erro que ao cancelar estamos mandando cancelar 1 centavo a mais do que criamos na transação da Getnet.
- Corrigida função colocando um round para que os valores fiquem iguais.
- Criados testes que quebravam sem o round no caso os valores 2428.72 que virava 242871 e 299.9 que virava 29989
- A ideia do round foi tirada da biblioteca da Rede que também fazia assim. 
- CLI-11141